### PR TITLE
restore version info

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.2</version>
+                <version>4.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -117,11 +117,13 @@
                 </executions>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                    <!--<dirty>-DEV</dirty>-->
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>
                         ${project.build.outputDirectory}/git.properties
                     </generateGitPropertiesFilename>
+                    <gitDescribe>
+                        <dirty>-DEV</dirty>
+                    </gitDescribe>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- bump git-commit-id-plugin to v4.0.0
- move dirty-tag in correct position

fixes #21